### PR TITLE
build: update to create a standalone executable

### DIFF
--- a/.github/workflows/pytest-workflow.yml
+++ b/.github/workflows/pytest-workflow.yml
@@ -1,0 +1,67 @@
+name: Testing Workflow
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
+      os:
+        required: true
+        type: string
+    secrets:
+      coverage_token:
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  run-pytest-coverage:
+    runs-on: ${{ inputs.os }}
+    steps: 
+      - name: Harden Runner
+        uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
+        with:
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            api.codecov.io:443
+            api.github.com:443
+            cli.codecov.io:443
+            codecov.io:443
+            files.pythonhosted.org:443
+            github.com:443
+            pypi.org:443
+            storage.googleapis.com:443
+            uploader.codecov.io:443
+
+      - name: Check out the commit
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+
+      - name: Set up Python
+        uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0
+        with:
+          python-version: ${{ inputs.version }}
+
+      - name: Install testing dependencies
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install -r requirements.txt -r requirements-dev.txt
+
+      - name: Test build and install
+        run: python3 -m pip install .
+
+      - name: Test with pytest
+        run: python3 -m pytest --nbmake --cov=sansmic --cov=tests examples/ tests/
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
+        with:
+          token: ${{ secrets.coverage_token }}
+          flags: ${{ inputs.os }}
+
+      - name: Test uninstall
+        if: success() || failure()
+        # Allow upload to codecov to fail but not fail all tests
+        run: python3 -m pip uninstall -y sansmic

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Action | Run PyInstaller
         run: |
-          pyinstaller -P src/python --collect-all sansmic --hidden-import sansmic --hidden-import sansmic.libsansmic --hidden-import sansmic.app -n sansmic sansmic.py
+          pyinstaller -p src/python --collect-all sansmic --hidden-import sansmic --hidden-import sansmic.libsansmic --hidden-import sansmic.app -n sansmic sansmic.py
 
       - name: Action | Zip the directory
         run: Compress-Archive -Path dist/sansmic -Destination sansmic-$SANSMIC_VERSION-win64-standalone.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,20 +39,22 @@ jobs:
       - name: Setup | Get the sansmic version number
         id: vars
         run: |
-          python -c "import sansmic; print('sansmic_version='+sansmic.__version__)" >> "$GITHUB_ENV"
-          echo "sha_short=$(git rev-parse --short HEAD)" >> "$GITHUB_ENV"
+          python -c "import sansmic; print('sansmic_version='+sansmic.__version__)" >> "$GITHUB_OUTPUT"
+          echo "sha_short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Setup | Create script file
         run: |
           echo "${{ steps.vars.outputs.sansmic_version }}"
           echo "${{ steps.vars.outputs.sha_short }}"
           echo "print('Sansmic is starting...')" > sansmic.py
+          echo "import sansmic" >> sansmic.py
           echo "import sansmic.app" >> sansmic.py
+          echo "import sansmic.libsansmic" >> sansmic.py
           echo "sansmic.app.run()" >> sansmic.py
 
       - name: Action | Run PyInstaller
         run: |
-          pyinstaller --collect-all sansmic --hidden-import click --hidden-import pandas --hidden-import pybind11 --hidden-import numpy --hidden-import h5py --hidden-import pyyaml --hidden-import lasio --hidden-import sansmic --hidden-import sansmic.libsansmic --hidden-import sansmic.app -n sansmic --add-binary src/python/sansmic/libsansmic.cp312-win_amd64.pyd:_internal/sansmic sansmic.py
+          pyinstaller --collect-all sansmic --hidden-import click --hidden-import pandas --hidden-import pybind11 --hidden-import numpy --hidden-import h5py --hidden-import pyyaml --hidden-import lasio -n sansmic sansmic.py
 
       - name: Action | Upload Artifacts
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
           pyinstaller -p src/python --collect-all sansmic --hidden-import sansmic --hidden-import sansmic.libsansmic --hidden-import sansmic.app -n sansmic sansmic.py
 
       - name: Action | Zip the directory
-        run: Compress-Archive -Path dist/sansmic -Destination sansmic-$SANSMIC_VERSION-win64-standalone.zip
+        run: Compress-Archive -Path dist/sansmic -Destination dist/pyin-$SANSMIC_VERSION-win64.zip
 
       - name: Action | Upload Artifacts
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,8 @@ jobs:
     name: Build standalone executable for Windows
     runs-on: [windows-latest]
     continue-on-error: true
-
+    env:
+      SANSMIC_VERSION: ${{ }}
     steps:
       - name: Setup | Install python
         uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0
@@ -34,11 +35,13 @@ jobs:
       - name: Setup | Install Dependencies
         run: |
           pip install -r requirements.txt -r requirements-exe.txt
-          pip install .
+          pip install -e .
 
       - name: Setup | Get the sansmic version number
+        id: sansmic_version
         run: |
-          python -c "import sansmic; print('SANSMIC_VERSION='+sansmic.__version__)" >> "$GITHUB_ENV"
+          python -c "import sansmic; print('sansmic_version='+sansmic.__version__)" >> "$GITHUB_OUTPUT"
+          echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
       - name: Setup | Create script file
         run: |
@@ -48,15 +51,15 @@ jobs:
 
       - name: Action | Run PyInstaller
         run: |
-          pyinstaller --collect-all sansmic --collect-all click --hidden-import click --hidden-import pandas --hidden-import pybind11 --hidden-import numpy --hidden-import h5py --hidden-import pyyaml --hidden-import lasio --hidden-import sansmic --hidden-import sansmic.libsansmic --hidden-import sansmic.app -n sansmic sansmic.py
+          pyinstaller -p src/python -p src/python/sansmic --collect-all sansmic --collect-all click --hidden-import click --hidden-import pandas --hidden-import pybind11 --hidden-import numpy --hidden-import h5py --hidden-import pyyaml --hidden-import lasio --hidden-import sansmic --hidden-import sansmic.libsansmic --hidden-import sansmic.app -n sansmic sansmic.py
 
       - name: Action | Zip the directory
-        run: Compress-Archive -Path dist/sansmic -Destination dist/sansmic-standalone-"$SANSMIC_VERSION"-win64.zip
+        run: Compress-Archive -Path dist/sansmic -Destination dist/exec-sansmic-${{ steps.vars.outputs.sansmic_version }}.${{ steps.vars.outputs.sha_short }}-win64.zip
 
       - name: Action | Upload Artifacts
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
-          name: pyinst-windows
+          name: pyinst-exec-win64
           path: ./dist/*.zip
 
   build_wheels:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,15 +46,14 @@ jobs:
           python -c "import sansmic; print('sansmic_version='+sansmic.__version__)" >> $Env:GITHUB_ENV
           echo "sha_short=$(git rev-parse --short HEAD)" >> $Env:GITHUB_ENV
 
-      - name: Setup | Create script file
-        run: |
-          echo "${{ env.sansmic_version }}"
-          echo "${{ env.sha_short }}"
-          sansmic-convert tests/baseline.dat tests/example.toml
-
       - name: Action | Run PyInstaller
         run: |
-          pyinstaller --collect-all sansmic --collect-all click --hidden-import sansmic --hidden-import click --hidden-import pandas --hidden-import pybind11 --hidden-import numpy --hidden-import h5py --hidden-import pyyaml --hidden-import lasio -n sansmic --add-binary src/python/sansmic/libsansmic.cp312-win_amd64.pyd:sansmic --add-data tests/example.toml:. src/python/sansmic/app.py
+          pyinstaller --collect-all sansmic --collect-all click --hidden-import sansmic --hidden-import click --hidden-import pandas --hidden-import pybind11 --hidden-import numpy --hidden-import h5py --hidden-import pyyaml --hidden-import lasio -n sansmic --add-binary src/python/sansmic/libsansmic.cp312-win_amd64.pyd:sansmic src/python/sansmic/app.py
+
+      - name: Action | Create examples
+        run: |
+          mkdir dist/sansmic/examples
+          sansmic-convert tests/baseline.dat dist/sansmic/examples/baseline.toml
 
       - name: Action | Upload Artifacts
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,13 +39,13 @@ jobs:
       - name: Setup | Get the sansmic version number
         id: vars
         run: |
-          python -c "import sansmic; print('sansmic_version='+sansmic.__version__)" >> "$GITHUB_OUTPUT"
-          echo "sha_short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+          python -c "import sansmic; print('sansmic_version='+sansmic.__version__)" >> "$GITHUB_ENV"
+          echo "sha_short=$(git rev-parse --short HEAD)" >> "$GITHUB_ENV"
 
       - name: Setup | Create script file
         run: |
-          echo "${{ steps.vars.outputs.sansmic_version }}"
-          echo "${{ steps.vars.outputs.sha_short }}"
+          echo "${{ env.sansmic_version }}"
+          echo "${{ env.sha_short }}"
           echo "print('Sansmic is starting...')" > sansmic.py
           echo "import sansmic" >> sansmic.py
           echo "import sansmic.app" >> sansmic.py
@@ -54,12 +54,12 @@ jobs:
 
       - name: Action | Run PyInstaller
         run: |
-          pyinstaller --collect-all sansmic --hidden-import click --hidden-import pandas --hidden-import pybind11 --hidden-import numpy --hidden-import h5py --hidden-import pyyaml --hidden-import lasio -n sansmic sansmic.py
+          pyinstaller --collect-all sansmic --collect-all click --hidden-import sansmic.libsansmic --hidden-import click --hidden-import pandas --hidden-import pybind11 --hidden-import numpy --hidden-import h5py --hidden-import pyyaml --hidden-import lasio -n sansmic --add-binary src/python/sansmic/libsansmic.cp312-win_amd64.pyd:sansmic sansmic.py
 
       - name: Action | Upload Artifacts
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
-          name: "sansmic-${{ steps.vars.outputs.sansmic_version }}-${{ steps.vars.outputs.sha_short }}-win64-exe"
+          name: "sansmic-${{ env.sansmic_version }}-${{ env.sha_short }}-win64-exe"
           path: ./dist/sansmic
 
   build_wheels:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,8 @@ jobs:
     runs-on: [windows-latest]
     continue-on-error: true
     env:
-      sansmic_version: 1.0.2-post
-      sha_short: dummy
+      sansmic_version: 0.0.0+local
+      sha_short: unreal
 
     steps:
       - name: Setup | Install python
@@ -50,15 +50,16 @@ jobs:
         run: |
           echo "${{ env.sansmic_version }}"
           echo "${{ env.sha_short }}"
+          sansmic-convert tests/baseline.dat tests/example.toml
 
       - name: Action | Run PyInstaller
         run: |
-          pyinstaller --collect-all sansmic --collect-all click --hidden-import sansmic --hidden-import click --hidden-import pandas --hidden-import pybind11 --hidden-import numpy --hidden-import h5py --hidden-import pyyaml --hidden-import lasio -n sansmic --add-binary src/python/sansmic/libsansmic.cp312-win_amd64.pyd:sansmic src/python/sansmic/app.py
+          pyinstaller --collect-all sansmic --collect-all click --hidden-import sansmic --hidden-import click --hidden-import pandas --hidden-import pybind11 --hidden-import numpy --hidden-import h5py --hidden-import pyyaml --hidden-import lasio -n sansmic --add-binary src/python/sansmic/libsansmic.cp312-win_amd64.pyd:sansmic --add-data tests/example.toml:. src/python/sansmic/app.py
 
       - name: Action | Upload Artifacts
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
-          name: "sansmic-${{ env.sansmic_version }}-${{ env.sha_short }}-win64-exe"
+          name: "sansmic-${{ env.sansmic_version }}-standalone-win_amd64"
           path: ./dist/sansmic
 
   build_wheels:
@@ -195,10 +196,18 @@ jobs:
         path: dist
         merge-multiple: true
 
+    - name: Setup | Download the standalone executable
+      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+      with:
+        pattern: sansmic-*-standalone-win_amd64
+        path: dist
+        merge-multiple: true
+
     - name: Action | Sign the dists with Sigstore
       uses: sigstore/gh-action-sigstore-python@f514d46b907ebcd5bedc05145c03b69c1edd8b46 # v3.0.0
       with:
         inputs: >-
+          ./dist/*.zip
           ./dist/*.tar.gz
           ./dist/*.whl
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,7 @@ jobs:
     name: Build standalone executable for Windows
     runs-on: [windows-latest]
     continue-on-error: true
-    env:
-      SANSMIC_VERSION: ${{ }}
+
     steps:
       - name: Setup | Install python
         uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'main'
+      - 'executable'
     paths-ignore:
       - '.github/**'
       - '!.github/workflows/release.yml'
@@ -16,30 +17,75 @@ permissions:
   contents: read
 
 jobs:
+  build_executable:
+    name: Build standalone executable for Windows
+    runs-on: [windows-latest]
+    continue-on-error: true
+
+    steps:
+      - name: Setup | Harden Runner
+        uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
+        with:
+          egress-policy: audit
+
+      - name: Setup | Install python
+        uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0
+        with:
+          python-version: '3.12'
+
+      - name: Setup | Checkout Code
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+
+      - name: Setup | Install Dependencies
+        run: |
+          pip install -r requirements.txt -r requirements-exe.txt
+          pip install -e .
+
+      - name: Setup | Get the sansmic version number
+        run: |
+          python -c "import sansmic; print('SANSMIC_VERSION='+sansmic.__version__)" >> "$GITHUB_ENV"
+
+      - name: Setup | Create script file
+        run: |
+          echo "print('Sansmic is starting...')" > sansmic.py
+          echo "import sansmic.app" >> sansmic.py
+          echo "sansmic.app.run()" >> sansmic.py
+
+      - name: Action | Run PyInstaller
+        run: |
+          pyinstaller -P src\\python\\ --collect-all sansmic --hidden-import sansmic --hidden-import sansmic.libsansmic --hidden-import sansmic.app -n sansmic sansmic.py
+
+      - name: Action | Zip the directory
+        run: Compress-Archive -Path dist\\sansmic -Destination sansmic-$SANSMIC_VERSION-win64-standalone.zip
+
+      - name: Action | Upload Artifacts
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          path: ./dist/*.zip
+
   build_wheels:
     name: Build distribution 📦 on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    if: ${{ startsWith(github.ref, 'refs/tags/') && github.repository == 'sandialabs/sansmic' }}  # only publish to PyPI on tag pushes
     strategy:
       matrix:
         # macos-13 is an intel runner, macos-14 is apple silicon
         os: [ubuntu-latest, windows-latest, macos-13, macos-14]
 
     steps:
-      - name: Harden Runner
+      - name: Setup | Harden Runner
         uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
         with:
           egress-policy: audit
 
-      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+      - name: Setup | Checkout Code
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
 
-      - uses: pypa/cibuildwheel@7940a4c0e76eb2030e473a5f864f291f63ee879b # v2.21.0
-        #    ...
-        # with:
-        #   package-dir: .
-        #   output-dir: wheelhouse
-        #   config-file: "{package}/pyproject.toml"
+      - name: Action | Build Wheels
+        uses: pypa/cibuildwheel@7940a4c0e76eb2030e473a5f864f291f63ee879b # v2.21.0
 
-      - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+      - name: Action | Upload Artifacts
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
           name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
           path: ./wheelhouse/*.whl
@@ -47,21 +93,24 @@ jobs:
   make_sdist:
     name: Make SDist artifact 📦
     runs-on: ubuntu-latest
+    if: ${{ startsWith(github.ref, 'refs/tags/') && github.repository == 'sandialabs/sansmic' }}  # only publish to PyPI on tag pushes
     steps:
-    - name: Harden Runner
+    - name: Setup | Harden Runner
       uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
       with:
         egress-policy: audit
 
-    - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+    - name: Setup | Checkout Code
+      uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
       with:
         fetch-depth: 0  # Optional, use if you use setuptools_scm
         submodules: true  # Optional, use if you have submodules
 
-    - name: Build SDist
+    - name: Action | Build SDist
       run: pipx run build --sdist
 
-    - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+    - name: Action | Upload Artifacts
+      uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
       with:
         name: cibw-sdist
         path: dist/*.tar.gz
@@ -80,13 +129,14 @@ jobs:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
 
     steps:
-    - name: Download all the dists
+    - name: Setup | Download all the dists
       uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       with:
         pattern: cibw-*
         path: dist
         merge-multiple: true
-    - name: Publish distribution 📦 to TestPyPI
+
+    - name: Action | Publish distribution 📦 to TestPyPI
       uses: pypa/gh-action-pypi-publish@f7600683efdcb7656dec5b29656edb7bc586e597 # release/v1
       with:
         skip-existing: true
@@ -106,19 +156,21 @@ jobs:
     permissions:
       id-token: write
     runs-on: ubuntu-latest
+
     steps:
-    - name: Harden Runner
+    - name: Setup | Harden Runner
       uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
       with:
         egress-policy: audit
 
-    - name: Download all the dists
+    - name: Setup | Download all the dists
       uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       with:
         pattern: cibw-*
         path: dist
         merge-multiple: true
-    - name: Publish distribution 📦 to PyPI
+
+    - name: Setup | Publish distribution 📦 to PyPI
       uses: pypa/gh-action-pypi-publish@f7600683efdcb7656dec5b29656edb7bc586e597 # release/v1
       with:
         attestations: true
@@ -131,25 +183,28 @@ jobs:
     needs:
     - publish-to-pypi
     runs-on: ubuntu-latest
+    if: ${{ startsWith(github.ref, 'refs/tags/') && github.repository == 'sandialabs/sansmic' }}  # only publish to PyPI on tag pushes
 
     permissions:
       contents: write  # IMPORTANT: mandatory for making GitHub Releases
       id-token: write  # IMPORTANT: mandatory for sigstore
 
     steps:
-    - name: Download all the dists
+    - name: Setup | Download all the dists
       uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       with:
         pattern: cibw-*
         path: dist
         merge-multiple: true
-    - name: Sign the dists with Sigstore
+
+    - name: Action | Sign the dists with Sigstore
       uses: sigstore/gh-action-sigstore-python@f514d46b907ebcd5bedc05145c03b69c1edd8b46 # v3.0.0
       with:
         inputs: >-
           ./dist/*.tar.gz
           ./dist/*.whl
-    - name: Create GitHub Release
+
+    - name: Action | Create GitHub Release
       env:
         GITHUB_TOKEN: ${{ github.token }}
       run: >-
@@ -157,7 +212,9 @@ jobs:
         '${{ github.ref_name }}'
         --repo '${{ github.repository }}'
         --notes ""
-    - name: Upload artifact signatures to GitHub Release
+
+    - name: Action | Upload artifact signatures to GitHub Release
+      if: success() || failure()
       env:
         GITHUB_TOKEN: ${{ github.token }}
       # Upload to GitHub Release using the `gh` CLI.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,11 +23,6 @@ jobs:
     continue-on-error: true
 
     steps:
-      - name: Setup | Harden Runner
-        uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
-        with:
-          egress-policy: audit
-
       - name: Setup | Install python
         uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Action | Run PyInstaller
         run: |
-          pyinstaller -P src\\python\\ --collect-all sansmic --hidden-import sansmic --hidden-import sansmic.libsansmic --hidden-import sansmic.app -n sansmic sansmic.py
+          pyinstaller -P src/python --collect-all sansmic --hidden-import sansmic --hidden-import sansmic.libsansmic --hidden-import sansmic.app -n sansmic sansmic.py
 
       - name: Action | Zip the directory
         run: Compress-Archive -Path dist\\sansmic -Destination sansmic-$SANSMIC_VERSION-win64-standalone.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,15 +50,10 @@ jobs:
         run: |
           echo "${{ env.sansmic_version }}"
           echo "${{ env.sha_short }}"
-          echo "print('Sansmic is starting...')" > sansmic.py
-          echo "import sansmic" >> sansmic.py
-          echo "import sansmic.app" >> sansmic.py
-          echo "import sansmic.libsansmic" >> sansmic.py
-          echo "sansmic.app.run()" >> sansmic.py
 
       - name: Action | Run PyInstaller
         run: |
-          pyinstaller --collect-all sansmic --collect-all click --hidden-import sansmic --hidden-import click --hidden-import pandas --hidden-import pybind11 --hidden-import numpy --hidden-import h5py --hidden-import pyyaml --hidden-import lasio -n sansmic --add-binary src/python/sansmic/libsansmic.cp312-win_amd64.pyd:sansmic sansmic.py
+          pyinstaller --collect-all sansmic --collect-all click --hidden-import sansmic --hidden-import click --hidden-import pandas --hidden-import pybind11 --hidden-import numpy --hidden-import h5py --hidden-import pyyaml --hidden-import lasio -n sansmic --add-binary src/python/sansmic/libsansmic.cp312-win_amd64.pyd:sansmic src/python/app.py
 
       - name: Action | Upload Artifacts
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
           pyinstaller -P src/python --collect-all sansmic --hidden-import sansmic --hidden-import sansmic.libsansmic --hidden-import sansmic.app -n sansmic sansmic.py
 
       - name: Action | Zip the directory
-        run: Compress-Archive -Path dist\\sansmic -Destination sansmic-$SANSMIC_VERSION-win64-standalone.zip
+        run: Compress-Archive -Path dist/sansmic -Destination sansmic-$SANSMIC_VERSION-win64-standalone.zip
 
       - name: Action | Upload Artifacts
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,9 @@ jobs:
     name: Build standalone executable for Windows
     runs-on: [windows-latest]
     continue-on-error: true
+    env:
+      sansmic_version: 1.0.2-post
+      sha_short: dummy
 
     steps:
       - name: Setup | Install python
@@ -34,7 +37,8 @@ jobs:
       - name: Setup | Install Dependencies
         run: |
           pip install -r requirements.txt -r requirements-exe.txt
-          pip install -e .
+          pip install .
+          python setup.py build_ext -i
 
       - name: Setup | Get the sansmic version number
         id: vars
@@ -54,7 +58,7 @@ jobs:
 
       - name: Action | Run PyInstaller
         run: |
-          pyinstaller --collect-all sansmic --collect-all click --hidden-import sansmic.libsansmic --hidden-import click --hidden-import pandas --hidden-import pybind11 --hidden-import numpy --hidden-import h5py --hidden-import pyyaml --hidden-import lasio -n sansmic --add-binary src/python/sansmic/libsansmic.cp312-win_amd64.pyd:sansmic sansmic.py
+          pyinstaller --collect-all sansmic --collect-all click --hidden-import sansmic --hidden-import click --hidden-import pandas --hidden-import pybind11 --hidden-import numpy --hidden-import h5py --hidden-import pyyaml --hidden-import lasio -n sansmic --add-binary src/python/sansmic/libsansmic.cp312-win_amd64.pyd:sansmic sansmic.py
 
       - name: Action | Upload Artifacts
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup | Install Dependencies
         run: |
           pip install -r requirements.txt -r requirements-exe.txt
-          pip install -e .
+          pip install .
 
       - name: Setup | Get the sansmic version number
         run: |
@@ -48,14 +48,15 @@ jobs:
 
       - name: Action | Run PyInstaller
         run: |
-          pyinstaller -p src/python --collect-all sansmic --hidden-import sansmic --hidden-import sansmic.libsansmic --hidden-import sansmic.app -n sansmic sansmic.py
+          pyinstaller --collect-all sansmic --collect-all click --hidden-import click --hidden-import pandas --hidden-import pybind11 --hidden-import numpy --hidden-import h5py --hidden-import pyyaml --hidden-import lasio --hidden-import sansmic --hidden-import sansmic.libsansmic --hidden-import sansmic.app -n sansmic sansmic.py
 
       - name: Action | Zip the directory
-        run: Compress-Archive -Path dist/sansmic -Destination dist/pyin-$SANSMIC_VERSION-win64.zip
+        run: Compress-Archive -Path dist/sansmic -Destination dist/sansmic-standalone-"$SANSMIC_VERSION"-win64.zip
 
       - name: Action | Upload Artifacts
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
+          name: pyinst-windows
           path: ./dist/*.zip
 
   build_wheels:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,31 +35,31 @@ jobs:
         run: |
           pip install -r requirements.txt -r requirements-exe.txt
           pip install -e .
+          dir
+          dir src/python/sansmic
 
       - name: Setup | Get the sansmic version number
-        id: sansmic_version
+        id: vars
         run: |
           python -c "import sansmic; print('sansmic_version='+sansmic.__version__)" >> "$GITHUB_OUTPUT"
-          echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+          echo "sha_short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Setup | Create script file
         run: |
+          echo "%{{ steps.vars.outputs. }}"
           echo "print('Sansmic is starting...')" > sansmic.py
           echo "import sansmic.app" >> sansmic.py
           echo "sansmic.app.run()" >> sansmic.py
 
       - name: Action | Run PyInstaller
         run: |
-          pyinstaller -p src/python -p src/python/sansmic --collect-all sansmic --collect-all click --hidden-import click --hidden-import pandas --hidden-import pybind11 --hidden-import numpy --hidden-import h5py --hidden-import pyyaml --hidden-import lasio --hidden-import sansmic --hidden-import sansmic.libsansmic --hidden-import sansmic.app -n sansmic sansmic.py
-
-      - name: Action | Zip the directory
-        run: Compress-Archive -Path dist/sansmic -Destination dist/exec-sansmic-${{ steps.vars.outputs.sansmic_version }}.${{ steps.vars.outputs.sha_short }}-win64.zip
+          pyinstaller -p src/python -p src/python/sansmic --collect-all sansmic --collect-all sansmic.libsansmic --collect-all click --hidden-import click --hidden-import pandas --hidden-import pybind11 --hidden-import numpy --hidden-import h5py --hidden-import pyyaml --hidden-import lasio --hidden-import sansmic --hidden-import sansmic.libsansmic --hidden-import sansmic.app -n sansmic sansmic.py
 
       - name: Action | Upload Artifacts
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
-          name: pyinst-exec-win64
-          path: ./dist/*.zip
+          name: sansmic-${{ steps.vars.outputs.sansmic_version }}-${{ steps.vars.outputs.sha_short }}-win64-exe
+          path: ./dist/sansmic
 
   build_wheels:
     name: Build distribution 📦 on ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,8 +43,8 @@ jobs:
       - name: Setup | Get the sansmic version number
         id: vars
         run: |
-          python -c "import sansmic; print('sansmic_version='+sansmic.__version__)" >> "$GITHUB_ENV"
-          echo "sha_short=$(git rev-parse --short HEAD)" >> "$GITHUB_ENV"
+          python -c "import sansmic; print('sansmic_version='+sansmic.__version__)" >> $Env:GITHUB_ENV
+          echo "sha_short=$(git rev-parse --short HEAD)" >> $Env:GITHUB_ENV
 
       - name: Setup | Create script file
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Action | Run PyInstaller
         run: |
-          pyinstaller --collect-all sansmic --collect-all click --hidden-import sansmic --hidden-import click --hidden-import pandas --hidden-import pybind11 --hidden-import numpy --hidden-import h5py --hidden-import pyyaml --hidden-import lasio -n sansmic --add-binary src/python/sansmic/libsansmic.cp312-win_amd64.pyd:sansmic src/python/app.py
+          pyinstaller --collect-all sansmic --collect-all click --hidden-import sansmic --hidden-import click --hidden-import pandas --hidden-import pybind11 --hidden-import numpy --hidden-import h5py --hidden-import pyyaml --hidden-import lasio -n sansmic --add-binary src/python/sansmic/libsansmic.cp312-win_amd64.pyd:sansmic src/python/sansmic/app.py
 
       - name: Action | Upload Artifacts
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,8 +35,6 @@ jobs:
         run: |
           pip install -r requirements.txt -r requirements-exe.txt
           pip install -e .
-          dir
-          dir src/python/sansmic
 
       - name: Setup | Get the sansmic version number
         id: vars
@@ -53,12 +51,12 @@ jobs:
 
       - name: Action | Run PyInstaller
         run: |
-          pyinstaller -p src/python -p src/python/sansmic --collect-all sansmic --collect-all sansmic.libsansmic --collect-all click --hidden-import click --hidden-import pandas --hidden-import pybind11 --hidden-import numpy --hidden-import h5py --hidden-import pyyaml --hidden-import lasio --hidden-import sansmic --hidden-import sansmic.libsansmic --hidden-import sansmic.app -n sansmic sansmic.py
+          pyinstaller --collect-all sansmic --hidden-import click --hidden-import pandas --hidden-import pybind11 --hidden-import numpy --hidden-import h5py --hidden-import pyyaml --hidden-import lasio --hidden-import sansmic --hidden-import sansmic.libsansmic --hidden-import sansmic.app -n sansmic --add-binary src/python/sansmic/libsansmic.cp312-win_amd64.pyd:_internal/sansmic sansmic.py
 
       - name: Action | Upload Artifacts
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
-          name: sansmic-${{ steps.vars.outputs.sansmic_version }}-${{ steps.vars.outputs.sha_short }}-win64-exe
+          name: "sansmic-${{ steps.vars.outputs.sansmic_version }}-${{ steps.vars.outputs.sha_short }}-win64-exe"
           path: ./dist/sansmic
 
   build_wheels:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,12 +39,13 @@ jobs:
       - name: Setup | Get the sansmic version number
         id: vars
         run: |
-          python -c "import sansmic; print('sansmic_version='+sansmic.__version__)" >> "$GITHUB_OUTPUT"
-          echo "sha_short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+          python -c "import sansmic; print('sansmic_version='+sansmic.__version__)" >> "$GITHUB_ENV"
+          echo "sha_short=$(git rev-parse --short HEAD)" >> "$GITHUB_ENV"
 
       - name: Setup | Create script file
         run: |
-          echo "%{{ steps.vars.outputs. }}"
+          echo "${{ steps.vars.outputs.sansmic_version }}"
+          echo "${{ steps.vars.outputs.sha_short }}"
           echo "print('Sansmic is starting...')" > sansmic.py
           echo "import sansmic.app" >> sansmic.py
           echo "sansmic.app.run()" >> sansmic.py

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Build and publish Python 🐍 distribution 📦 to PyPI
+name: Build - Publish - Release
 
 on:
   push:

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -35,8 +35,23 @@ jobs:
       run: |
         git checkout -B ${{ github.ref_name }} ${{ github.sha }}
 
-    - name: Action | Semantic Version Release
+    - name: Action | Check if release is needed
       id: release
+      # Adjust tag with desired version if applicable.
+      uses: python-semantic-release/python-semantic-release@c1bcfdbb994243ac7cf419365d5894d6bfb2950e # v9.12.0
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        git_committer_name: "github-actions"
+        git_committer_email: "actions@users.noreply.github.com"
+        build: false
+        changelog: false
+        commit: false
+        push: false
+        tag: false
+        vcs_release: false
+
+    - name: Action | Semantic Release - Update version
+      if: steps.release.outputs.released == 'true'
       # Adjust tag with desired version if applicable.
       uses: python-semantic-release/python-semantic-release@c1bcfdbb994243ac7cf419365d5894d6bfb2950e # v9.12.0
       with:
@@ -50,8 +65,16 @@ jobs:
         tag: false
         vcs_release: false
 
-    - name: Action | Create Pull Request
+    - name: Action | Create Pull Request - Release
+      if: steps.release.outputs.released == 'true'
       run: |
-        gh pr create -B main -H staging --title 'Merge staging into main' --body 'Created by Github action: semantic-release.yml'
+        gh pr create -B main -H staging --title "release: Merge into main and create tag as v${{ steps.release.outputs.version }}" --body 'Created by Github action: semantic-release.yml'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Action | Create Pull Request - Chore
+      if: steps.release.outputs.released == 'false'
+      run: |
+        gh pr create -B main -H staging --title 'chore: Merge non-code changes into main' --body 'Created by Github action: semantic-release.yml'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -12,6 +12,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     concurrency: release
+    if: ${{ github.repository == 'sandialabs/sansmic' }}  # do not run everywhere
 
     permissions:
       id-token: write
@@ -49,15 +50,8 @@ jobs:
         tag: false
         vcs_release: false
 
-    - name: create pull request
+    - name: Action | Create Pull Request
       run: |
         gh pr create -B main -H staging --title 'Merge staging into main' --body 'Created by Github action: semantic-release.yml'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-    #- name: Publish | Upload to GitHub Release Assets
-    #  uses: python-semantic-release/publish-action@3dccc469c6577f385b5e844ed29677fb1f4cb4b6 # v9.10.1
-    #  if: steps.release.outputs.released == 'true'
-    #  with:
-    #    github_token: ${{ secrets.GITHUB_TOKEN }}
-    #    tag: ${{ steps.release.outputs.tag }}

--- a/README.md
+++ b/README.md
@@ -37,7 +37,11 @@ numpy and pandas packages.
 Installation can be accomplished most easily by using the PyPI.
 It can also be installed by downloading a wheel from the [releases]
 in this repository, or by cloning this repository and building it
-yourself.
+yourself. Finally, a standalone executable has been created that
+will be added to each release for Windows users that are unable
+due to install Python on their corporate computers (see the releases 
+on the right side of the page).
+
 
 #### PyPI wheels
 To install a pre-compiled version of sansmic, use the pip command

--- a/requirements-exe.txt
+++ b/requirements-exe.txt
@@ -1,0 +1,6 @@
+h5py==3.12.1
+openpyxl==3.1.5
+tabulate==0.9.0
+lasio==0.31
+pyinstaller==6.11.0
+pyyaml==6.0.2

--- a/src/python/sansmic/app.py
+++ b/src/python/sansmic/app.py
@@ -492,3 +492,7 @@ def convert(dat_file, out_file=None, full=False):
         logger.critical(str(e))
         raise e
     logger.debug("Successfully wrote scenario to {}".format(out_file))
+
+
+if __name__ == "__main__":
+    run()


### PR DESCRIPTION
## Issue
There have been several individuals who have let the developers know that their employers will not permit them to install Python on their systems at a system or user level. However, they are authorized to install a standalone program that would run sansmic.

## Solution
The pyinstaller package provides the ability to create a standalone executable from python and compiled code. This PR pulls in the build instructions to create a standalone package and updates the CI architecture to create such a package when a release is created. The executable and libraries are zipped into a file that is signed and uploaded to the release as an artifact.